### PR TITLE
Add support of server adaptive ack

### DIFF
--- a/lib/editor-socketio-server.js
+++ b/lib/editor-socketio-server.js
@@ -15,7 +15,7 @@ function DummyLogger () {
   };
 }
 
-function EditorSocketIOServer (document, operations, docId, mayWrite, operationCallback, operationEventCallback) {
+function EditorSocketIOServer (document, operations, docId, mayWrite, operationCallback, operationEventCallback, adaptiveAck) {
   EventEmitter.call(this);
   Server.call(this, document, operations);
   this.users = {};
@@ -23,6 +23,8 @@ function EditorSocketIOServer (document, operations, docId, mayWrite, operationC
   this.mayWrite = mayWrite || function (_, cb) { cb(true); };
   this.operationCallback = operationCallback;
   this.operationEventCallback = operationEventCallback;
+  this.adaptiveAck = adaptiveAck || false;
+  this.adaptiveAckDelay = 2000;
   this.socketOperations = [];
   this.isBusy = false;
   this.logger = DummyLogger();
@@ -159,7 +161,20 @@ EditorSocketIOServer.prototype.onOperation = function (socket, revision, operati
     }
     this.getClient(clientId).selection = wrappedPrime.meta;
     revision = this.operations.length;
-    socket.emit('ack', revision);
+    // adaptive ack: when there is only one user in the doc,
+    // delay emit ack and client will buffer more operations before sending
+    // which should greatly reduce operations fragmentation, server traffic and computes
+    if (this.adaptiveAck) {
+      if (this.users && Object.keys(this.users).length === 1) {
+        setTimeout(function () {
+          socket.emit('ack', revision);
+        }, this.adaptiveAckDelay);
+      } else {
+        socket.emit('ack', revision);
+      }
+    } else {
+      socket.emit('ack', revision);
+    }
     socket.broadcast.to(this.docId).emit(
       'operation', clientId, revision,
       wrappedPrime.wrapped.toJSON(), wrappedPrime.meta

--- a/lib/editor-socketio-server.js
+++ b/lib/editor-socketio-server.js
@@ -15,7 +15,7 @@ function DummyLogger () {
   };
 }
 
-function EditorSocketIOServer (document, operations, docId, mayWrite, operationCallback, operationEventCallback, adaptiveAck) {
+function EditorSocketIOServer (document, operations, docId, mayWrite, operationCallback, operationEventCallback, adaptiveAckDelay) {
   EventEmitter.call(this);
   Server.call(this, document, operations);
   this.users = {};
@@ -23,8 +23,8 @@ function EditorSocketIOServer (document, operations, docId, mayWrite, operationC
   this.mayWrite = mayWrite || function (_, cb) { cb(true); };
   this.operationCallback = operationCallback;
   this.operationEventCallback = operationEventCallback;
-  this.adaptiveAck = adaptiveAck || false;
-  this.adaptiveAckDelay = 2000;
+  this.adaptiveAck = !!(typeof adaptiveAckDelay === 'number' && adaptiveAckDelay);
+  this.adaptiveAckDelay = adaptiveAckDelay;
   this.socketOperations = [];
   this.isBusy = false;
   this.logger = DummyLogger();


### PR DESCRIPTION
When there is only one user in the doc, we can delay emit ack and client will buffer more operations before sending.
This should greatly reduce operations fragmentation, server traffic and computes.