### PR TITLE
feature/allow `documentMaxLength` as callback function

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -13,6 +13,9 @@ ot.Server = (function (global) {
     this.setDocumentMaxLength(null);
   }
 
+  /**
+   * @param {number | (() => number) | null} maxLength
+   */
   Server.prototype.setDocumentMaxLength = function (maxLength) {
     this.documentMaxLength = maxLength;
   };
@@ -34,10 +37,18 @@ ot.Server = (function (global) {
 
     // ... and apply that on the document.
     var newDocument = operation.apply(this.document);
+
+    const maxLen =
+      typeof this.documentMaxLength === "function"
+        ? this.documentMaxLength()
+        : this.documentMaxLength;
+
     // ignore if exceed the max length of document
-    if(typeof this.documentMaxLength === 'number' && 
-        newDocument.length > this.documentMaxLength && 
-        newDocument.length > this.document.length) {
+    if (
+      typeof maxLen === "number" &&
+      newDocument.length > maxLen &&
+      newDocument.length > this.document.length
+    ) {
       return;
     }
     this.document = newDocument;


### PR DESCRIPTION
Make the `setDocumentMaxLength` function and the `documentMaxLength` property able to accept a callback function, which allows dynamic adjustment on max document length.